### PR TITLE
Feature: AST Visitor

### DIFF
--- a/examples/main.rai
+++ b/examples/main.rai
@@ -16,7 +16,7 @@ env: "development"
 
 # array type definition with mandatory size
 <[3: number]>
-my_array: [1 2 3]
+my_array: [3: 1 2 3]
 
 # slice type definition with no size specified
 <[number]>

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -69,6 +69,11 @@ type TypeExpression interface {
 
 type TypeIdentifier string
 
+func NewTypeIdentifier(name string) TypeExpression {
+	ident := TypeIdentifier(name)
+	return &ident
+}
+
 func (i *TypeIdentifier) Accept(visitor Visitor) error {
 	return visitor.VisitTypeIdentifier(i)
 }

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -1,10 +1,40 @@
 package parser
 
-// Implements Expression
+type Visitor interface {
+	VisitScope(s *Scope) error
+	VisitDefinition(d *Definition) error
+	VisitTypeDefinition(d *TypeDefinition) error
+	VisitTypeIdentifier(i *TypeIdentifier) error
+	VisitFunctionType(f *FunctionType) error
+	VisitRecordType(r *RecordType) error
+	VisitSliceType(s *SliceType) error
+	VisitArrayType(a *ArrayType) error
+	VisitGroupType(g *GroupType) error
+	VisitSumType(s *SumType) error
+	VisitSumTypeVariant(v *SumTypeVariant) error
+	VisitIdentifier(i *Identifier) error
+	VisitInvocation(i *Invocation) error
+	VisitLambda(l *LambdaLiteral) error
+	VisitRecord(r *RecordLiteral) error
+	VisitArray(a *ArrayLiteral) error
+	VisitSlice(s *SliceLiteral) error
+	VisitNumber(n *NumberLiteral) error
+	VisitString(s *StringLiteral) error
+	VisitCharacter(c *CharacterLiteral) error
+}
+
+type Node interface {
+	Accept(visitor Visitor) error
+}
+
 type Scope struct {
 	typeDefinitions []TypeDefinition
 	definitions     []Definition
 	expressions     []Expression
+}
+
+func (s *Scope) Accept(visitor Visitor) error {
+	return visitor.VisitScope(s)
 }
 
 type TypeDefinition struct {
@@ -12,32 +42,60 @@ type TypeDefinition struct {
 	typeExpression TypeExpression
 }
 
+func (d *TypeDefinition) Accept(visitor Visitor) error {
+	return visitor.VisitTypeDefinition(d)
+}
+
 type Definition struct {
-	typeExpression TypeExpression // if not defined explicitly, inferred from expression
+	typeExpression TypeExpression
 	identifier     Identifier
 	parameters     []Identifier
 	expression     Expression
 }
 
-type Expression interface{}
+func (d *Definition) Accept(visitor Visitor) error {
+	return visitor.VisitDefinition(d)
+}
 
-type TypeExpression interface{}
+type Expression interface {
+	Node
+}
+
+type TypeExpression interface {
+	Node
+}
 
 // *** Type Expressions ***
 
-type TypeIdentifier string // e.g. string, number, list, person, etc.
+type TypeIdentifier string
+
+func (i *TypeIdentifier) Accept(visitor Visitor) error {
+	return visitor.VisitTypeIdentifier(i)
+}
 
 type FunctionType struct {
 	parameterType TypeExpression
 	returnType    TypeExpression
-} // e.g. number -> (number -> number); argumentType -> returnType
+}
+
+func (f *FunctionType) Accept(visitor Visitor) error {
+	return visitor.VisitFunctionType(f)
+}
 
 type RecordType struct {
 	fields map[Identifier]TypeExpression
-} // e.g. { name: string, age: number }
+}
+
+func (r *RecordType) Accept(visitor Visitor) error {
+	return visitor.VisitRecordType(r)
+}
 
 type SliceType struct {
 	elementType TypeExpression
+}
+
+func (s *SliceType) Accept(visitor Visitor) error {
+	return visitor.VisitSliceType(s)
 }
 
 type ArrayType struct {
@@ -45,12 +103,24 @@ type ArrayType struct {
 	elementType TypeExpression
 }
 
+func (a *ArrayType) Accept(visitor Visitor) error {
+	return visitor.VisitArrayType(a)
+}
+
 type GroupType struct {
 	typeExpressions []TypeExpression
 }
 
+func (g *GroupType) Accept(visitor Visitor) error {
+	return visitor.VisitGroupType(g)
+}
+
 type SumType struct {
 	variants []SumTypeVariant
+}
+
+func (s *SumType) Accept(visitor Visitor) error {
+	return visitor.VisitSumType(s)
 }
 
 type SumTypeVariant struct {
@@ -58,12 +128,24 @@ type SumTypeVariant struct {
 	typeExpression TypeExpression
 }
 
+func (v *SumTypeVariant) Accept(visitor Visitor) error {
+	return visitor.VisitSumTypeVariant(v)
+}
+
 // *** Expressions ***
 
 type Identifier string
 
+func (i *Identifier) Accept(visitor Visitor) error {
+	return visitor.VisitIdentifier(i)
+}
+
 type Invocation struct {
 	arguments []Expression
+}
+
+func (i *Invocation) Accept(visitor Visitor) error {
+	return visitor.VisitInvocation(i)
 }
 
 type LambdaLiteral struct {
@@ -71,8 +153,16 @@ type LambdaLiteral struct {
 	expression Expression
 }
 
+func (l *LambdaLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitLambda(l)
+}
+
 type RecordLiteral struct {
 	fields map[Identifier]Expression
+}
+
+func (r *RecordLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitRecord(r)
 }
 
 type ArrayLiteral struct {
@@ -80,12 +170,32 @@ type ArrayLiteral struct {
 	elements []Expression
 }
 
+func (a *ArrayLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitArray(a)
+}
+
 type SliceLiteral struct {
 	elements []Expression
 }
 
+func (s *SliceLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitSlice(s)
+}
+
 type NumberLiteral string
+
+func (n *NumberLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitNumber(n)
+}
 
 type StringLiteral string
 
+func (s *StringLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitString(s)
+}
+
 type CharacterLiteral string
+
+func (c *CharacterLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitCharacter(c)
+}

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -28,8 +28,8 @@ type Node interface {
 }
 
 type Scope struct {
-	TypeDefinitions []TypeDefinition
-	Definitions     []Definition
+	TypeDefinitions []*TypeDefinition
+	Definitions     []*Definition
 	Expressions     []Expression
 }
 
@@ -49,7 +49,7 @@ func (d *TypeDefinition) Accept(visitor Visitor) error {
 type Definition struct {
 	TypeExpression TypeExpression
 	Identifier     Identifier
-	Parameters     []Identifier
+	Parameters     []*Identifier
 	Expression     Expression
 }
 
@@ -116,7 +116,7 @@ func (g *GroupType) Accept(visitor Visitor) error {
 }
 
 type SumType struct {
-	Variants []SumTypeVariant
+	Variants []*SumTypeVariant
 }
 
 func (s *SumType) Accept(visitor Visitor) error {
@@ -149,7 +149,7 @@ func (i *Invocation) Accept(visitor Visitor) error {
 }
 
 type LambdaLiteral struct {
-	Parameters []Identifier
+	Parameters []*Identifier
 	Expression Expression
 }
 

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -28,9 +28,9 @@ type Node interface {
 }
 
 type Scope struct {
-	typeDefinitions []TypeDefinition
-	definitions     []Definition
-	expressions     []Expression
+	TypeDefinitions []TypeDefinition
+	Definitions     []Definition
+	Expressions     []Expression
 }
 
 func (s *Scope) Accept(visitor Visitor) error {
@@ -38,8 +38,8 @@ func (s *Scope) Accept(visitor Visitor) error {
 }
 
 type TypeDefinition struct {
-	identifier     TypeIdentifier
-	typeExpression TypeExpression
+	Identifier     TypeIdentifier
+	TypeExpression TypeExpression
 }
 
 func (d *TypeDefinition) Accept(visitor Visitor) error {
@@ -47,10 +47,10 @@ func (d *TypeDefinition) Accept(visitor Visitor) error {
 }
 
 type Definition struct {
-	typeExpression TypeExpression
-	identifier     Identifier
-	parameters     []Identifier
-	expression     Expression
+	TypeExpression TypeExpression
+	Identifier     Identifier
+	Parameters     []Identifier
+	Expression     Expression
 }
 
 func (d *Definition) Accept(visitor Visitor) error {
@@ -74,8 +74,8 @@ func (i *TypeIdentifier) Accept(visitor Visitor) error {
 }
 
 type FunctionType struct {
-	parameterType TypeExpression
-	returnType    TypeExpression
+	ParameterType TypeExpression
+	ReturnType    TypeExpression
 }
 
 func (f *FunctionType) Accept(visitor Visitor) error {
@@ -83,7 +83,7 @@ func (f *FunctionType) Accept(visitor Visitor) error {
 }
 
 type RecordType struct {
-	fields map[Identifier]TypeExpression
+	Fields map[Identifier]TypeExpression
 }
 
 func (r *RecordType) Accept(visitor Visitor) error {
@@ -91,7 +91,7 @@ func (r *RecordType) Accept(visitor Visitor) error {
 }
 
 type SliceType struct {
-	elementType TypeExpression
+	ElementType TypeExpression
 }
 
 func (s *SliceType) Accept(visitor Visitor) error {
@@ -99,8 +99,8 @@ func (s *SliceType) Accept(visitor Visitor) error {
 }
 
 type ArrayType struct {
-	size        uint64
-	elementType TypeExpression
+	Size        uint64
+	ElementType TypeExpression
 }
 
 func (a *ArrayType) Accept(visitor Visitor) error {
@@ -108,7 +108,7 @@ func (a *ArrayType) Accept(visitor Visitor) error {
 }
 
 type GroupType struct {
-	typeExpressions []TypeExpression
+	TypeExpressions []TypeExpression
 }
 
 func (g *GroupType) Accept(visitor Visitor) error {
@@ -116,7 +116,7 @@ func (g *GroupType) Accept(visitor Visitor) error {
 }
 
 type SumType struct {
-	variants []SumTypeVariant
+	Variants []SumTypeVariant
 }
 
 func (s *SumType) Accept(visitor Visitor) error {
@@ -124,8 +124,8 @@ func (s *SumType) Accept(visitor Visitor) error {
 }
 
 type SumTypeVariant struct {
-	identifier     Identifier
-	typeExpression TypeExpression
+	Identifier     Identifier
+	TypeExpression TypeExpression
 }
 
 func (v *SumTypeVariant) Accept(visitor Visitor) error {
@@ -141,7 +141,7 @@ func (i *Identifier) Accept(visitor Visitor) error {
 }
 
 type Invocation struct {
-	arguments []Expression
+	Arguments []Expression
 }
 
 func (i *Invocation) Accept(visitor Visitor) error {
@@ -149,8 +149,8 @@ func (i *Invocation) Accept(visitor Visitor) error {
 }
 
 type LambdaLiteral struct {
-	parameters []Identifier
-	expression Expression
+	Parameters []Identifier
+	Expression Expression
 }
 
 func (l *LambdaLiteral) Accept(visitor Visitor) error {
@@ -158,7 +158,7 @@ func (l *LambdaLiteral) Accept(visitor Visitor) error {
 }
 
 type RecordLiteral struct {
-	fields map[Identifier]Expression
+	Fields map[Identifier]Expression
 }
 
 func (r *RecordLiteral) Accept(visitor Visitor) error {
@@ -166,8 +166,8 @@ func (r *RecordLiteral) Accept(visitor Visitor) error {
 }
 
 type ArrayLiteral struct {
-	size     uint64
-	elements []Expression
+	Size     uint64
+	Elements []Expression
 }
 
 func (a *ArrayLiteral) Accept(visitor Visitor) error {
@@ -175,7 +175,7 @@ func (a *ArrayLiteral) Accept(visitor Visitor) error {
 }
 
 type SliceLiteral struct {
-	elements []Expression
+	Elements []Expression
 }
 
 func (s *SliceLiteral) Accept(visitor Visitor) error {

--- a/parser/comparator.go
+++ b/parser/comparator.go
@@ -26,11 +26,6 @@ func (c *Comparator) observe(node Node) {
 
 /*** Visitor Methods ***/
 
-// NOTE: These visitor methods get called on the expectation tree.
-//		 The c.current Node points to the matching node of
-//		 the tree being checked and is updated and checked by the
-//		 visitor methods.
-
 func (c *Comparator) VisitScope(expected *Scope) error {
 	current, ok := c.current.(*Scope)
 

--- a/parser/comparator.go
+++ b/parser/comparator.go
@@ -17,11 +17,20 @@ func NewComparator(compared Node) Comparator {
 // with the expected Node, returning an error if the equality
 // comparison fails.
 func (c *Comparator) Compare(expected Node) error {
+	if expected == nil {
+		return fmt.Errorf("should not expect nil, please check the AST")
+	}
+
 	return expected.Accept(c)
 }
 
-func (c *Comparator) observe(node Node) {
+func (c *Comparator) observe(node Node) error {
+	if node == nil {
+		return fmt.Errorf("should not observe nil")
+	}
+
 	c.current = node
+	return nil
 }
 
 /*** Visitor Methods ***/
@@ -55,13 +64,17 @@ func (c *Comparator) VisitDefinition(expected *Definition) error {
 		return nodeTypeError("Definition")
 	}
 
-	c.observe(current.TypeExpression)
+	if err := c.observe(current.TypeExpression); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.TypeExpression); err != nil {
 		return err
 	}
 
-	c.observe(&current.Identifier)
+	if err := c.observe(&current.Identifier); err != nil {
+		return err
+	}
 
 	if err := c.Compare(&expected.Identifier); err != nil {
 		return err
@@ -71,7 +84,9 @@ func (c *Comparator) VisitDefinition(expected *Definition) error {
 		return err
 	}
 
-	c.observe(current.Expression)
+	if err := c.observe(current.Expression); err != nil {
+		return err
+	}
 
 	if err := expected.Expression.Accept(c); err != nil {
 		return err
@@ -87,13 +102,17 @@ func (c *Comparator) VisitTypeDefinition(expected *TypeDefinition) error {
 		return nodeTypeError("TypeDefinition")
 	}
 
-	c.observe(&current.Identifier)
+	if err := c.observe(&current.Identifier); err != nil {
+		return err
+	}
 
 	if err := c.Compare(&expected.Identifier); err != nil {
 		return err
 	}
 
-	c.observe(current.TypeExpression)
+	if err := c.observe(current.TypeExpression); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.TypeExpression); err != nil {
 		return err
@@ -123,13 +142,17 @@ func (c *Comparator) VisitFunctionType(expected *FunctionType) error {
 		return nodeTypeError("FunctionType")
 	}
 
-	c.observe(current.ParameterType)
+	if err := c.observe(current.ParameterType); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.ParameterType); err != nil {
 		return err
 	}
 
-	c.observe(current.ReturnType)
+	if err := c.observe(current.ReturnType); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.ReturnType); err != nil {
 		return err
@@ -159,7 +182,9 @@ func (c *Comparator) VisitSliceType(expected *SliceType) error {
 		return nodeTypeError("SliceType")
 	}
 
-	c.observe(current.ElementType)
+	if err := c.observe(current.ElementType); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.ElementType); err != nil {
 		return err
@@ -179,7 +204,9 @@ func (c *Comparator) VisitArrayType(expected *ArrayType) error {
 		return fmt.Errorf("expected array of size %d, but got size %d", expected.Size, current.Size)
 	}
 
-	c.observe(current.ElementType)
+	if err := c.observe(current.ElementType); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.ElementType); err != nil {
 		return err
@@ -223,13 +250,17 @@ func (c *Comparator) VisitSumTypeVariant(expected *SumTypeVariant) error {
 		return nodeTypeError("SumTypeVariant")
 	}
 
-	c.observe(&current.Identifier)
+	if err := c.observe(&current.Identifier); err != nil {
+		return err
+	}
 
 	if err := c.Compare(&expected.Identifier); err != nil {
 		return err
 	}
 
-	c.observe(current.TypeExpression)
+	if err := c.observe(current.TypeExpression); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.TypeExpression); err != nil {
 		return err
@@ -277,7 +308,9 @@ func (c *Comparator) VisitLambda(expected *LambdaLiteral) error {
 		return err
 	}
 
-	c.observe(current.Expression)
+	if err := c.observe(current.Expression); err != nil {
+		return err
+	}
 
 	if err := c.Compare(expected.Expression); err != nil {
 		return err
@@ -386,7 +419,9 @@ func compareSlices[T Node](c *Comparator, what string, expected []T, current []T
 	}
 
 	for i, d := range expected {
-		c.observe(current[i])
+		if err := c.observe(current[i]); err != nil {
+			return err
+		}
 
 		if err := c.Compare(d); err != nil {
 			return err
@@ -408,10 +443,12 @@ func compareMaps[T Node](c *Comparator, expected map[Identifier]T, current map[I
 			return fmt.Errorf("field `%s` not found", ident)
 		}
 
-		c.observe(otherExpr)
+		if err := c.observe(otherExpr); err != nil {
+			return err
+		}
 
 		if err := c.Compare(expr); err != nil {
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/parser/comparator.go
+++ b/parser/comparator.go
@@ -3,17 +3,19 @@ package parser
 import "fmt"
 
 type Comparator struct {
-	source  Node
 	current Node
 }
 
+// Creates a new Comparator with a Node to be compared as argument.
 func NewComparator(compared Node) Comparator {
 	return Comparator{
-		source:  compared,
 		current: compared,
 	}
 }
 
+// Compares the Node given to the NewComparator constructor
+// with the expected Node, returning an error if the equality
+// comparison fails.
 func (c *Comparator) Compare(expected Node) error {
 	return expected.Accept(c)
 }
@@ -112,7 +114,7 @@ func (c *Comparator) VisitTypeIdentifier(expected *TypeIdentifier) error {
 		return nodeTypeError("TypeIdentifier")
 	}
 
-	if current != expected {
+	if string(*current) != string(*expected) {
 		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
 	}
 
@@ -248,7 +250,7 @@ func (c *Comparator) VisitIdentifier(expected *Identifier) error {
 		return nodeTypeError("Identifier")
 	}
 
-	if current != expected {
+	if string(*current) != string(*expected) {
 		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
 	}
 
@@ -342,7 +344,7 @@ func (c *Comparator) VisitNumber(expected *NumberLiteral) error {
 		return nodeTypeError("NumberLiteral")
 	}
 
-	if current != expected {
+	if string(*current) != string(*expected) {
 		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
 	}
 
@@ -356,7 +358,7 @@ func (c *Comparator) VisitString(expected *StringLiteral) error {
 		return nodeTypeError("StringLiteral")
 	}
 
-	if current != expected {
+	if string(*current) != string(*expected) {
 		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
 	}
 

--- a/parser/comparator.go
+++ b/parser/comparator.go
@@ -1,0 +1,421 @@
+package parser
+
+import "fmt"
+
+type Comparator struct {
+	source  Node
+	current Node
+}
+
+func NewComparator(compared Node) Comparator {
+	return Comparator{
+		source:  compared,
+		current: compared,
+	}
+}
+
+func (c *Comparator) Compare(expected Node) error {
+	return expected.Accept(c)
+}
+
+func (c *Comparator) observe(node Node) {
+	c.current = node
+}
+
+/*** Visitor Methods ***/
+
+// NOTE: These visitor methods get called on the expectation tree.
+//		 The c.current Node points to the matching node of
+//		 the tree being checked and is updated and checked by the
+//		 visitor methods.
+
+func (c *Comparator) VisitScope(expected *Scope) error {
+	current, ok := c.current.(*Scope)
+
+	if !ok {
+		return nodeTypeError("Scope")
+	}
+
+	if err := compareSlices(c, "definitions", expected.Definitions, current.Definitions); err != nil {
+		return err
+	}
+
+	if err := compareSlices(c, "type definitions", expected.TypeDefinitions, current.TypeDefinitions); err != nil {
+		return err
+	}
+
+	if err := compareSlices(c, "expressions", expected.Expressions, current.Expressions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitDefinition(expected *Definition) error {
+	current, ok := c.current.(*Definition)
+
+	if !ok {
+		return nodeTypeError("Definition")
+	}
+
+	c.observe(current.TypeExpression)
+
+	if err := c.Compare(expected.TypeExpression); err != nil {
+		return err
+	}
+
+	c.observe(&current.Identifier)
+
+	if err := c.Compare(&expected.Identifier); err != nil {
+		return err
+	}
+
+	if err := compareSlices(c, "parameters", expected.Parameters, current.Parameters); err != nil {
+		return err
+	}
+
+	c.observe(current.Expression)
+
+	if err := expected.Expression.Accept(c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitTypeDefinition(expected *TypeDefinition) error {
+	current, ok := c.current.(*TypeDefinition)
+
+	if !ok {
+		return nodeTypeError("TypeDefinition")
+	}
+
+	c.observe(&current.Identifier)
+
+	if err := c.Compare(&expected.Identifier); err != nil {
+		return err
+	}
+
+	c.observe(current.TypeExpression)
+
+	if err := c.Compare(expected.TypeExpression); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitTypeIdentifier(expected *TypeIdentifier) error {
+	current, ok := c.current.(*TypeIdentifier)
+
+	if !ok {
+		return nodeTypeError("TypeIdentifier")
+	}
+
+	if current != expected {
+		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitFunctionType(expected *FunctionType) error {
+	current, ok := c.current.(*FunctionType)
+
+	if !ok {
+		return nodeTypeError("FunctionType")
+	}
+
+	c.observe(current.ParameterType)
+
+	if err := c.Compare(expected.ParameterType); err != nil {
+		return err
+	}
+
+	c.observe(current.ReturnType)
+
+	if err := c.Compare(expected.ReturnType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitRecordType(expected *RecordType) error {
+	current, ok := c.current.(*RecordType)
+
+	if !ok {
+		return nodeTypeError("RecordType")
+	}
+
+	if err := compareMaps(c, expected.Fields, current.Fields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitSliceType(expected *SliceType) error {
+	current, ok := c.current.(*SliceType)
+
+	if !ok {
+		return nodeTypeError("SliceType")
+	}
+
+	c.observe(current.ElementType)
+
+	if err := c.Compare(expected.ElementType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitArrayType(expected *ArrayType) error {
+	current, ok := c.current.(*ArrayType)
+
+	if !ok {
+		return nodeTypeError("SliceType")
+	}
+
+	if expected.Size != current.Size {
+		return fmt.Errorf("expected array of size %d, but got size %d", expected.Size, current.Size)
+	}
+
+	c.observe(current.ElementType)
+
+	if err := c.Compare(expected.ElementType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitGroupType(expected *GroupType) error {
+	current, ok := c.current.(*GroupType)
+
+	if !ok {
+		return nodeTypeError("GroupType")
+	}
+
+	if err := compareSlices(c, "type expressions", expected.TypeExpressions, current.TypeExpressions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitSumType(expected *SumType) error {
+	current, ok := c.current.(*SumType)
+
+	if !ok {
+		return nodeTypeError("SumType")
+	}
+
+	if err := compareSlices(c, "variants", expected.Variants, current.Variants); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitSumTypeVariant(expected *SumTypeVariant) error {
+	current, ok := c.current.(*SumTypeVariant)
+
+	if !ok {
+		return nodeTypeError("SumTypeVariant")
+	}
+
+	c.observe(&current.Identifier)
+
+	if err := c.Compare(&expected.Identifier); err != nil {
+		return err
+	}
+
+	c.observe(current.TypeExpression)
+
+	if err := c.Compare(expected.TypeExpression); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitIdentifier(expected *Identifier) error {
+	current, ok := c.current.(*Identifier)
+
+	if !ok {
+		return nodeTypeError("Identifier")
+	}
+
+	if current != expected {
+		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitInvocation(expected *Invocation) error {
+	current, ok := c.current.(*Invocation)
+
+	if !ok {
+		return nodeTypeError("Invocation")
+	}
+
+	if err := compareSlices(c, "arguments", expected.Arguments, current.Arguments); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitLambda(expected *LambdaLiteral) error {
+	current, ok := c.current.(*LambdaLiteral)
+
+	if !ok {
+		return nodeTypeError("LambdaLiteral")
+	}
+
+	if err := compareSlices(c, "parameters", expected.Parameters, current.Parameters); err != nil {
+		return err
+	}
+
+	c.observe(current.Expression)
+
+	if err := c.Compare(expected.Expression); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitRecord(expected *RecordLiteral) error {
+	current, ok := c.current.(*RecordLiteral)
+
+	if !ok {
+		return nodeTypeError("RecordLiteral")
+	}
+
+	if err := compareMaps(c, expected.Fields, current.Fields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitArray(expected *ArrayLiteral) error {
+	current, ok := c.current.(*ArrayLiteral)
+
+	if !ok {
+		return nodeTypeError("ArrayLiteral")
+	}
+
+	if expected.Size != current.Size {
+		return fmt.Errorf("expected array of size %d, but got size %d", expected.Size, current.Size)
+	}
+
+	if err := compareSlices(c, "elements", expected.Elements, current.Elements); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitSlice(expected *SliceLiteral) error {
+	current, ok := c.current.(*SliceLiteral)
+
+	if !ok {
+		return nodeTypeError("SliceLiteral")
+	}
+
+	if err := compareSlices(c, "elements", expected.Elements, current.Elements); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitNumber(expected *NumberLiteral) error {
+	current, ok := c.current.(*NumberLiteral)
+
+	if !ok {
+		return nodeTypeError("NumberLiteral")
+	}
+
+	if current != expected {
+		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitString(expected *StringLiteral) error {
+	current, ok := c.current.(*StringLiteral)
+
+	if !ok {
+		return nodeTypeError("StringLiteral")
+	}
+
+	if current != expected {
+		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitCharacter(expected *CharacterLiteral) error {
+	current, ok := c.current.(*CharacterLiteral)
+
+	if !ok {
+		return nodeTypeError("CharacterLiteral")
+	}
+
+	if current != expected {
+		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	}
+
+	return nil
+}
+
+/*** Helper Functions ***/
+
+func nodeTypeError(expected string) error {
+	return fmt.Errorf("expected node of type `%s`", expected)
+}
+
+func compareSlices[T Node](c *Comparator, what string, expected []T, current []T) error {
+	if len(expected) != len(current) {
+		return fmt.Errorf("expected %d %s, but got %d", len(expected), what, len(current))
+	}
+
+	for i, d := range expected {
+		c.observe(current[i])
+
+		if err := c.Compare(d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func compareMaps[T Node](c *Comparator, expected map[Identifier]T, current map[Identifier]T) error {
+	if len(expected) != len(current) {
+		return fmt.Errorf("expected %d fields, but got %d", len(expected), len(current))
+	}
+
+	for ident, expr := range expected {
+		otherExpr, ok := current[ident]
+
+		if !ok {
+			return fmt.Errorf("field `%s` not found", ident)
+		}
+
+		c.observe(otherExpr)
+
+		if err := c.Compare(expr); err != nil {
+			return nil
+		}
+	}
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,9 +30,9 @@ func (p *Parser) Parse() (Expression, error) {
 
 func (p *Parser) fileScope() (*Scope, error) {
 	scope := &Scope{
-		definitions:     make([]Definition, 0),
-		typeDefinitions: make([]TypeDefinition, 0),
-		expressions:     make([]Expression, 0),
+		Definitions:     make([]Definition, 0),
+		TypeDefinitions: make([]TypeDefinition, 0),
+		Expressions:     make([]Expression, 0),
 	}
 
 	for !p.match(token.EOF) {
@@ -46,9 +46,9 @@ func (p *Parser) fileScope() (*Scope, error) {
 
 func (p *Parser) scope() (*Scope, error) {
 	scope := &Scope{
-		definitions:     make([]Definition, 0),
-		typeDefinitions: make([]TypeDefinition, 0),
-		expressions:     make([]Expression, 0),
+		Definitions:     make([]Definition, 0),
+		TypeDefinitions: make([]TypeDefinition, 0),
+		Expressions:     make([]Expression, 0),
 	}
 
 	p.consume(token.OPEN_BRACE)
@@ -74,19 +74,19 @@ func (p *Parser) scopeItem(scope *Scope) error {
 		if err != nil {
 			return err
 		}
-		scope.definitions = append(scope.definitions, definition)
+		scope.Definitions = append(scope.Definitions, definition)
 	} else if p.match(token.TYPE) {
 		typeDefinition, err := p.typeDefinition()
 		if err != nil {
 			return err
 		}
-		scope.typeDefinitions = append(scope.typeDefinitions, typeDefinition)
+		scope.TypeDefinitions = append(scope.TypeDefinitions, typeDefinition)
 	} else {
 		expression, err := p.expression()
 		if err != nil {
 			return err
 		}
-		scope.expressions = append(scope.expressions, expression)
+		scope.Expressions = append(scope.Expressions, expression)
 	}
 
 	return nil
@@ -96,12 +96,12 @@ func (p *Parser) definition() (Definition, error) {
 	var err error
 
 	def := Definition{
-		parameters: []Identifier{},
+		Parameters: []Identifier{},
 	}
 
 	if p.match(token.OPEN_ANGLE) {
 		p.consume(token.OPEN_ANGLE)
-		def.typeExpression, err = p.typeExpression()
+		def.TypeExpression, err = p.typeExpression()
 		if err != nil {
 			return Definition{}, err
 		}
@@ -115,23 +115,23 @@ func (p *Parser) definition() (Definition, error) {
 		return Definition{}, err
 	}
 
-	def.identifier = Identifier(p.token.Literal)
+	def.Identifier = Identifier(p.token.Literal)
 
 	p.consume(token.IDENTIFIER)
 
 	for p.match(token.IDENTIFIER) {
 		param := Identifier(p.token.Literal)
-		def.parameters = append(def.parameters, param)
+		def.Parameters = append(def.Parameters, param)
 		p.consume(token.IDENTIFIER)
 	}
 
 	if p.match(token.COLON) {
 		p.consume(token.COLON)
-		if def.expression, err = p.expression(); err != nil {
+		if def.Expression, err = p.expression(); err != nil {
 			return Definition{}, err
 		}
 	} else if p.match(token.OPEN_BRACE) {
-		if def.expression, err = p.scope(); err != nil {
+		if def.Expression, err = p.scope(); err != nil {
 			return Definition{}, err
 		}
 	} else {
@@ -165,8 +165,8 @@ func (p *Parser) typeDefinition() (TypeDefinition, error) {
 	}
 
 	return TypeDefinition{
-		identifier:     ident,
-		typeExpression: typeExpression,
+		Identifier:     ident,
+		TypeExpression: typeExpression,
 	}, nil
 }
 
@@ -200,8 +200,8 @@ func (p *Parser) typeExpression() (TypeExpression, error) {
 		}
 
 		typeExpression = &FunctionType{
-			parameterType: typeExpression,
-			returnType:    returnTypeExpression,
+			ParameterType: typeExpression,
+			ReturnType:    returnTypeExpression,
 		}
 	}
 
@@ -235,13 +235,13 @@ func (p *Parser) typeGroup() (TypeExpression, error) {
 	p.consume(token.CLOSED_PAREN)
 
 	return &GroupType{
-		typeExpressions: typeExpressions,
+		TypeExpressions: typeExpressions,
 	}, nil
 }
 
 func (p *Parser) typeSum() (TypeExpression, error) {
 	sumType := SumType{
-		variants: []SumTypeVariant{},
+		Variants: []SumTypeVariant{},
 	}
 
 	for p.match(token.PIPE) {
@@ -252,7 +252,7 @@ func (p *Parser) typeSum() (TypeExpression, error) {
 		}
 
 		variant := SumTypeVariant{
-			identifier: Identifier(p.token.Literal),
+			Identifier: Identifier(p.token.Literal),
 		}
 
 		p.consume(token.IDENTIFIER)
@@ -265,10 +265,10 @@ func (p *Parser) typeSum() (TypeExpression, error) {
 				return nil, err
 			}
 
-			variant.typeExpression = typeExpression
+			variant.TypeExpression = typeExpression
 		}
 
-		sumType.variants = append(sumType.variants, variant)
+		sumType.Variants = append(sumType.Variants, variant)
 	}
 
 	return &sumType, nil
@@ -277,7 +277,7 @@ func (p *Parser) typeSum() (TypeExpression, error) {
 func (p *Parser) typeRecord() (TypeExpression, error) {
 	p.consume(token.OPEN_BRACE)
 	recortType := RecordType{
-		fields: map[Identifier]TypeExpression{},
+		Fields: map[Identifier]TypeExpression{},
 	}
 
 	for p.match(token.IDENTIFIER) {
@@ -291,7 +291,7 @@ func (p *Parser) typeRecord() (TypeExpression, error) {
 		if err != nil {
 			return nil, err
 		}
-		recortType.fields[field] = typeExpression
+		recortType.Fields[field] = typeExpression
 	}
 
 	if err := p.expect(token.CLOSED_BRACE); err != nil {
@@ -330,8 +330,8 @@ func (p *Parser) typeArrayOrSlice() (TypeExpression, error) {
 		}
 
 		typeExpression = &ArrayType{
-			size:        size,
-			elementType: elementType,
+			Size:        size,
+			ElementType: elementType,
 		}
 	} else {
 		elementType, err := p.typeExpression()
@@ -341,7 +341,7 @@ func (p *Parser) typeArrayOrSlice() (TypeExpression, error) {
 		}
 
 		typeExpression = &SliceType{
-			elementType: elementType,
+			ElementType: elementType,
 		}
 	}
 
@@ -438,12 +438,12 @@ func (p *Parser) arrayOrSlice() (Expression, error) {
 		p.consume(token.COLON)
 
 		expression = &ArrayLiteral{
-			size:     size,
-			elements: elements,
+			Size:     size,
+			Elements: elements,
 		}
 	} else {
 		expression = &SliceLiteral{
-			elements: elements,
+			Elements: elements,
 		}
 	}
 
@@ -468,7 +468,7 @@ func (p *Parser) record() (Expression, error) {
 	p.consume(token.OPEN_BRACE)
 
 	recordLiteral := RecordLiteral{
-		fields: map[Identifier]Expression{},
+		Fields: map[Identifier]Expression{},
 	}
 
 	for p.match(token.IDENTIFIER) {
@@ -481,7 +481,7 @@ func (p *Parser) record() (Expression, error) {
 			return nil, err
 		}
 
-		recordLiteral.fields[field] = expression
+		recordLiteral.Fields[field] = expression
 	}
 
 	if err := p.expect(token.CLOSED_BRACE); err != nil {
@@ -497,24 +497,24 @@ func (p *Parser) lambda() (Expression, error) {
 	p.consume(token.BACKSLASH)
 
 	lambdaLiteral := LambdaLiteral{
-		parameters: []Identifier{},
+		Parameters: []Identifier{},
 	}
 
 	var err error
 
 	for p.match(token.IDENTIFIER) {
 		param := Identifier(p.token.Literal)
-		lambdaLiteral.parameters = append(lambdaLiteral.parameters, param)
+		lambdaLiteral.Parameters = append(lambdaLiteral.Parameters, param)
 		p.consume(token.IDENTIFIER)
 	}
 
 	if p.match(token.COLON) {
 		p.consume(token.COLON)
-		if lambdaLiteral.expression, err = p.expression(); err != nil {
+		if lambdaLiteral.Expression, err = p.expression(); err != nil {
 			return &Definition{}, err
 		}
 	} else if p.match(token.OPEN_BRACE) {
-		if lambdaLiteral.expression, err = p.scope(); err != nil {
+		if lambdaLiteral.Expression, err = p.scope(); err != nil {
 			return &Definition{}, err
 		}
 	} else {
@@ -528,7 +528,7 @@ func (p *Parser) invocation() (Expression, error) {
 	p.consume(token.OPEN_PAREN)
 
 	invocation := Invocation{
-		arguments: []Expression{},
+		Arguments: []Expression{},
 	}
 
 	for !p.match(token.EOF) && !p.match(token.CLOSED_PAREN) {
@@ -536,7 +536,7 @@ func (p *Parser) invocation() (Expression, error) {
 		if err != nil {
 			return nil, err
 		}
-		invocation.arguments = append(invocation.arguments, expression)
+		invocation.Arguments = append(invocation.Arguments, expression)
 	}
 
 	if err := p.expect(token.CLOSED_PAREN); err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -30,8 +30,8 @@ func (p *Parser) Parse() (Expression, error) {
 
 func (p *Parser) fileScope() (*Scope, error) {
 	scope := &Scope{
-		Definitions:     make([]Definition, 0),
-		TypeDefinitions: make([]TypeDefinition, 0),
+		Definitions:     make([]*Definition, 0),
+		TypeDefinitions: make([]*TypeDefinition, 0),
 		Expressions:     make([]Expression, 0),
 	}
 
@@ -46,8 +46,8 @@ func (p *Parser) fileScope() (*Scope, error) {
 
 func (p *Parser) scope() (*Scope, error) {
 	scope := &Scope{
-		Definitions:     make([]Definition, 0),
-		TypeDefinitions: make([]TypeDefinition, 0),
+		Definitions:     make([]*Definition, 0),
+		TypeDefinitions: make([]*TypeDefinition, 0),
 		Expressions:     make([]Expression, 0),
 	}
 
@@ -74,13 +74,13 @@ func (p *Parser) scopeItem(scope *Scope) error {
 		if err != nil {
 			return err
 		}
-		scope.Definitions = append(scope.Definitions, definition)
+		scope.Definitions = append(scope.Definitions, &definition)
 	} else if p.match(token.TYPE) {
 		typeDefinition, err := p.typeDefinition()
 		if err != nil {
 			return err
 		}
-		scope.TypeDefinitions = append(scope.TypeDefinitions, typeDefinition)
+		scope.TypeDefinitions = append(scope.TypeDefinitions, &typeDefinition)
 	} else {
 		expression, err := p.expression()
 		if err != nil {
@@ -96,7 +96,7 @@ func (p *Parser) definition() (Definition, error) {
 	var err error
 
 	def := Definition{
-		Parameters: []Identifier{},
+		Parameters: []*Identifier{},
 	}
 
 	if p.match(token.OPEN_ANGLE) {
@@ -121,7 +121,7 @@ func (p *Parser) definition() (Definition, error) {
 
 	for p.match(token.IDENTIFIER) {
 		param := Identifier(p.token.Literal)
-		def.Parameters = append(def.Parameters, param)
+		def.Parameters = append(def.Parameters, &param)
 		p.consume(token.IDENTIFIER)
 	}
 
@@ -241,7 +241,7 @@ func (p *Parser) typeGroup() (TypeExpression, error) {
 
 func (p *Parser) typeSum() (TypeExpression, error) {
 	sumType := SumType{
-		Variants: []SumTypeVariant{},
+		Variants: []*SumTypeVariant{},
 	}
 
 	for p.match(token.PIPE) {
@@ -268,7 +268,7 @@ func (p *Parser) typeSum() (TypeExpression, error) {
 			variant.TypeExpression = typeExpression
 		}
 
-		sumType.Variants = append(sumType.Variants, variant)
+		sumType.Variants = append(sumType.Variants, &variant)
 	}
 
 	return &sumType, nil
@@ -497,14 +497,14 @@ func (p *Parser) lambda() (Expression, error) {
 	p.consume(token.BACKSLASH)
 
 	lambdaLiteral := LambdaLiteral{
-		Parameters: []Identifier{},
+		Parameters: []*Identifier{},
 	}
 
 	var err error
 
 	for p.match(token.IDENTIFIER) {
 		param := Identifier(p.token.Literal)
-		lambdaLiteral.Parameters = append(lambdaLiteral.Parameters, param)
+		lambdaLiteral.Parameters = append(lambdaLiteral.Parameters, &param)
 		p.consume(token.IDENTIFIER)
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -199,7 +199,7 @@ func (p *Parser) typeExpression() (TypeExpression, error) {
 			return nil, err
 		}
 
-		typeExpression = FunctionType{
+		typeExpression = &FunctionType{
 			parameterType: typeExpression,
 			returnType:    returnTypeExpression,
 		}
@@ -211,7 +211,7 @@ func (p *Parser) typeExpression() (TypeExpression, error) {
 func (p *Parser) typeIdentifier() TypeExpression {
 	ident := TypeIdentifier(p.token.Literal)
 	p.consume(token.IDENTIFIER)
-	return ident
+	return &ident
 }
 
 func (p *Parser) typeGroup() (TypeExpression, error) {
@@ -234,7 +234,7 @@ func (p *Parser) typeGroup() (TypeExpression, error) {
 
 	p.consume(token.CLOSED_PAREN)
 
-	return GroupType{
+	return &GroupType{
 		typeExpressions: typeExpressions,
 	}, nil
 }
@@ -271,7 +271,7 @@ func (p *Parser) typeSum() (TypeExpression, error) {
 		sumType.variants = append(sumType.variants, variant)
 	}
 
-	return sumType, nil
+	return &sumType, nil
 }
 
 func (p *Parser) typeRecord() (TypeExpression, error) {
@@ -300,7 +300,7 @@ func (p *Parser) typeRecord() (TypeExpression, error) {
 
 	p.consume(token.CLOSED_BRACE)
 
-	return recortType, nil
+	return &recortType, nil
 }
 
 func (p *Parser) typeArrayOrSlice() (TypeExpression, error) {
@@ -329,7 +329,7 @@ func (p *Parser) typeArrayOrSlice() (TypeExpression, error) {
 			return nil, err
 		}
 
-		typeExpression = ArrayType{
+		typeExpression = &ArrayType{
 			size:        size,
 			elementType: elementType,
 		}
@@ -340,7 +340,7 @@ func (p *Parser) typeArrayOrSlice() (TypeExpression, error) {
 			return nil, err
 		}
 
-		typeExpression = SliceType{
+		typeExpression = &SliceType{
 			elementType: elementType,
 		}
 	}
@@ -379,13 +379,13 @@ func (p *Parser) expression() (Expression, error) {
 func (p *Parser) identifier() Expression {
 	ident := Identifier(p.token.Literal)
 	p.consume(token.IDENTIFIER)
-	return ident
+	return &ident
 }
 
 func (p *Parser) number() Expression {
 	num := NumberLiteral(p.token.Literal)
 	p.consume(token.NUMBER)
-	return num
+	return &num
 }
 
 func (p *Parser) string() (Expression, error) {
@@ -399,7 +399,7 @@ func (p *Parser) string() (Expression, error) {
 		return nil, err
 	}
 	p.consume(token.DOUBLE_QUOTE)
-	return str, nil
+	return &str, nil
 }
 
 func (p *Parser) character() (Expression, error) {
@@ -413,7 +413,7 @@ func (p *Parser) character() (Expression, error) {
 		return nil, err
 	}
 	p.consume(token.SINGLE_QUOTE)
-	return char, nil
+	return &char, nil
 }
 
 func (p *Parser) arrayOrSlice() (Expression, error) {
@@ -437,12 +437,12 @@ func (p *Parser) arrayOrSlice() (Expression, error) {
 
 		p.consume(token.COLON)
 
-		expression = ArrayLiteral{
+		expression = &ArrayLiteral{
 			size:     size,
 			elements: elements,
 		}
 	} else {
-		expression = SliceLiteral{
+		expression = &SliceLiteral{
 			elements: elements,
 		}
 	}
@@ -490,7 +490,7 @@ func (p *Parser) record() (Expression, error) {
 
 	p.consume(token.CLOSED_BRACE)
 
-	return recordLiteral, nil
+	return &recordLiteral, nil
 }
 
 func (p *Parser) lambda() (Expression, error) {
@@ -511,17 +511,17 @@ func (p *Parser) lambda() (Expression, error) {
 	if p.match(token.COLON) {
 		p.consume(token.COLON)
 		if lambdaLiteral.expression, err = p.expression(); err != nil {
-			return Definition{}, err
+			return &Definition{}, err
 		}
 	} else if p.match(token.OPEN_BRACE) {
 		if lambdaLiteral.expression, err = p.scope(); err != nil {
-			return Definition{}, err
+			return &Definition{}, err
 		}
 	} else {
-		return Definition{}, p.unexpected()
+		return &Definition{}, p.unexpected()
 	}
 
-	return lambdaLiteral, nil
+	return &lambdaLiteral, nil
 }
 
 func (p *Parser) invocation() (Expression, error) {
@@ -545,7 +545,7 @@ func (p *Parser) invocation() (Expression, error) {
 
 	p.consume(token.CLOSED_PAREN)
 
-	return invocation, nil
+	return &invocation, nil
 }
 
 /*** Parser utility methods ***/

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,33 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rfejzic1/raiton/lexer"
+)
+
+func parseAndCompare(t *testing.T, source string, expected Expression) {
+	l := lexer.New(source)
+	p := New(&l)
+	got, err := p.Parse()
+
+	if err != nil {
+		t.Fatalf("parse error: %s", err)
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("assertion failed: ASTs are not equal")
+	}
+}
+
+func TestParser(t *testing.T) {
+	source := ``
+	expected := Scope{
+		definitions:     make([]Definition, 0),
+		typeDefinitions: make([]TypeDefinition, 0),
+		expressions:     make([]Expression, 0),
+	}
+
+	parseAndCompare(t, source, &expected)
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -24,9 +24,9 @@ func parseAndCompare(t *testing.T, source string, expected Expression) {
 func TestParser(t *testing.T) {
 	source := ``
 	expected := Scope{
-		definitions:     make([]Definition, 0),
-		typeDefinitions: make([]TypeDefinition, 0),
-		expressions:     make([]Expression, 0),
+		Definitions:     make([]Definition, 0),
+		TypeDefinitions: make([]TypeDefinition, 0),
+		Expressions:     make([]Expression, 0),
 	}
 
 	parseAndCompare(t, source, &expected)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -24,13 +24,26 @@ func parseAndCompare(t *testing.T, source string, expected Expression) {
 
 func TestParser(t *testing.T) {
 	source := `
-	main: 0
+	type person: {
+	  name: string
+	  age: number
+	}
 	`
 
 	expected := Scope{
-		Definitions:     make([]*Definition, 0),
-		TypeDefinitions: make([]*TypeDefinition, 0),
-		Expressions:     make([]Expression, 0),
+		Definitions: []*Definition{},
+		TypeDefinitions: []*TypeDefinition{
+			{
+				Identifier: TypeIdentifier("person"),
+				TypeExpression: &RecordType{
+					Fields: map[Identifier]TypeExpression{
+						Identifier("name"): NewTypeIdentifier("string"),
+						Identifier("age"):  NewTypeIdentifier("number"),
+					},
+				},
+			},
+		},
+		Expressions: []Expression{},
 	}
 
 	parseAndCompare(t, source, &expected)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/rfejzic1/raiton/lexer"
@@ -16,13 +15,18 @@ func parseAndCompare(t *testing.T, source string, expected Expression) {
 		t.Fatalf("parse error: %s", err)
 	}
 
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("assertion failed: ASTs are not equal")
+	comp := NewComparator(got)
+
+	if err := comp.Compare(expected); err != nil {
+		t.Fatalf("assertion failed: %s", err)
 	}
 }
 
 func TestParser(t *testing.T) {
-	source := ``
+	source := `
+	main: 0
+	`
+
 	expected := Scope{
 		Definitions:     make([]*Definition, 0),
 		TypeDefinitions: make([]*TypeDefinition, 0),

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -24,8 +24,8 @@ func parseAndCompare(t *testing.T, source string, expected Expression) {
 func TestParser(t *testing.T) {
 	source := ``
 	expected := Scope{
-		Definitions:     make([]Definition, 0),
-		TypeDefinitions: make([]TypeDefinition, 0),
+		Definitions:     make([]*Definition, 0),
+		TypeDefinitions: make([]*TypeDefinition, 0),
 		Expressions:     make([]Expression, 0),
 	}
 


### PR DESCRIPTION
This PR implements the visitor pattern for decoupling operations on the Abstract Syntax Tree from the nodes of the tree.

The `Visitor` interface defines a method to visit each of the node types. For example:
```go
type Visitor interface {
    VisitScope(*Scope) error
    // rest of methods for other node types...
}
```

Each node of the tree implements the `Node` interface, that has the `Accept(Visitor) error` method, which just makes a call to the appropriate method on the `Visitor`. For example:
```go
func (s *Scope) Accept(visitor Visitor) error {
    return visitor.VisitScope(s)
}
```

This PR also has the implementation of the `Comparator` visitor, which does a tree comparison of the parsed AST and the
one expected. This is going to serve as an example of a concrete implementation of the `Visitor` interface, as well for testing.

An example of a test for the parser can be found in the *parser_test.go* file.