### PR TITLE
Rename module to raiton

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/rfejzic1/raiton/ast"
-	"github.com/rfejzic1/raiton/lexer"
-	"github.com/rfejzic1/raiton/parser"
+	"raiton/ast"
+	"raiton/lexer"
+	"raiton/parser"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cli/repl.go
+++ b/cli/repl.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rfejzic1/raiton/evaluator"
-	"github.com/rfejzic1/raiton/lexer"
-	"github.com/rfejzic1/raiton/object"
-	"github.com/rfejzic1/raiton/parser"
+	"raiton/evaluator"
+	"raiton/lexer"
+	"raiton/object"
+	"raiton/parser"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cli/tokenize.go
+++ b/cli/tokenize.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/rfejzic1/raiton/lexer"
-	"github.com/rfejzic1/raiton/token"
+	"raiton/lexer"
+	"raiton/token"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/rfejzic1/raiton/cli"
+	"raiton/cli"
 )
 
 func main() {

--- a/evaluator/builtin.go
+++ b/evaluator/builtin.go
@@ -3,8 +3,8 @@ package evaluator
 import (
 	"fmt"
 
-	"github.com/rfejzic1/raiton/ast"
-	"github.com/rfejzic1/raiton/object"
+	"raiton/ast"
+	"raiton/object"
 )
 
 var builtins = map[string]*object.Builtin{

--- a/evaluator/eval.go
+++ b/evaluator/eval.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/rfejzic1/raiton/ast"
-	"github.com/rfejzic1/raiton/object"
+	"raiton/ast"
+	"raiton/object"
 )
 
 type Evaluator struct {

--- a/evaluator/eval_test.go
+++ b/evaluator/eval_test.go
@@ -3,9 +3,9 @@ package evaluator
 import (
 	"testing"
 
-	"github.com/rfejzic1/raiton/lexer"
-	"github.com/rfejzic1/raiton/object"
-	"github.com/rfejzic1/raiton/parser"
+	"raiton/lexer"
+	"raiton/object"
+	"raiton/parser"
 )
 
 func testEvaluation(env *object.Environment, input string) (object.Object, error) {

--- a/evaluator/stack.go
+++ b/evaluator/stack.go
@@ -3,7 +3,7 @@ package evaluator
 import (
 	"fmt"
 
-	"github.com/rfejzic1/raiton/object"
+	"raiton/object"
 )
 
 type stack struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rfejzic1/raiton
+module raiton
 
 go 1.21.0
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,6 +1,6 @@
 package lexer
 
-import "github.com/rfejzic1/raiton/token"
+import "raiton/token"
 
 type lexMode uint
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"testing"
 
-	"github.com/rfejzic1/raiton/token"
+	"raiton/token"
 )
 
 type test struct {

--- a/object/object.go
+++ b/object/object.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rfejzic1/raiton/ast"
+	"raiton/ast"
 )
 
 type ObjectType string

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/rfejzic1/raiton/ast"
-	"github.com/rfejzic1/raiton/lexer"
-	"github.com/rfejzic1/raiton/token"
+	"raiton/ast"
+	"raiton/lexer"
+	"raiton/token"
 )
 
 type Parser struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"testing"
 
-	"github.com/rfejzic1/raiton/ast"
-	"github.com/rfejzic1/raiton/lexer"
+	"raiton/ast"
+	"raiton/lexer"
 )
 
 func parseAndCompare(t *testing.T, source string, expected ast.Expression) {


### PR DESCRIPTION
This PR introduces module name changes to the project. Now the module is called just `raiton`.