### PR TITLE
Improvement: Better function definitions and selector expressions in scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build
 temp
-repl
+/repl

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -11,7 +11,8 @@ type Visitor interface {
 	VisitRecord(n *RecordLiteral) error
 	VisitArray(n *ArrayLiteral) error
 	VisitSlice(n *SliceLiteral) error
-	VisitNumber(n *NumberLiteral) error
+	VisitInteger(n *IntegerLiteral) error
+	VisitFloat(n *FloatLiteral) error
 	VisitString(n *StringLiteral) error
 	VisitCharacter(n *CharacterLiteral) error
 	VisitBoolean(n *BooleanLiteral) error
@@ -69,7 +70,7 @@ type Selector struct {
 
 type SelectorItem struct {
 	Identifier *Identifier
-	Index      *NumberLiteral
+	Index      *IntegerLiteral
 }
 
 func NewIdentifierSelector(ident *Identifier) *SelectorItem {
@@ -82,7 +83,7 @@ func (i *SelectorItem) Accept(visitor Visitor) error {
 	return visitor.VisitSelectorItem(i)
 }
 
-func NewIndexSelector(num *NumberLiteral) *SelectorItem {
+func NewIndexSelector(num *IntegerLiteral) *SelectorItem {
 	return &SelectorItem{
 		Index: num,
 	}
@@ -159,15 +160,26 @@ func (s *SliceLiteral) Accept(visitor Visitor) error {
 	return visitor.VisitSlice(s)
 }
 
-type NumberLiteral string
+type IntegerLiteral int64
 
-func NewNumberLiteral(value string) *NumberLiteral {
-	num := NumberLiteral(value)
+func NewIntegerLiteral(value int64) *IntegerLiteral {
+	num := IntegerLiteral(value)
 	return &num
 }
 
-func (n *NumberLiteral) Accept(visitor Visitor) error {
-	return visitor.VisitNumber(n)
+func (n *IntegerLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitInteger(n)
+}
+
+type FloatLiteral float64
+
+func NewFloatLiteral(value float64) *FloatLiteral {
+	num := FloatLiteral(value)
+	return &num
+}
+
+func (n *FloatLiteral) Accept(visitor Visitor) error {
+	return visitor.VisitFloat(n)
 }
 
 type StringLiteral string

--- a/ast/comparator.go
+++ b/ast/comparator.go
@@ -208,15 +208,29 @@ func (c *Comparator) VisitSlice(expected *SliceLiteral) error {
 	return nil
 }
 
-func (c *Comparator) VisitNumber(expected *NumberLiteral) error {
-	current, ok := c.current.(*NumberLiteral)
+func (c *Comparator) VisitInteger(expected *IntegerLiteral) error {
+	current, ok := c.current.(*IntegerLiteral)
 
 	if !ok {
 		return nodeTypeError("NumberLiteral")
 	}
 
-	if string(*current) != string(*expected) {
-		return fmt.Errorf("expected `%s`, but got `%s`", string(*expected), string(*current))
+	if *current != *expected {
+		return fmt.Errorf("expected `%d`, but got `%d`", *expected, *current)
+	}
+
+	return nil
+}
+
+func (c *Comparator) VisitFloat(expected *FloatLiteral) error {
+	current, ok := c.current.(*FloatLiteral)
+
+	if !ok {
+		return nodeTypeError("FloatLiteral")
+	}
+
+	if *current != *expected {
+		return fmt.Errorf("expected `%g`, but got `%f`", *expected, *current)
 	}
 
 	return nil

--- a/ast/printer.go
+++ b/ast/printer.go
@@ -1,6 +1,9 @@
 package ast
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type Printer struct {
 	node Node
@@ -105,7 +108,7 @@ func (p *Printer) VisitSelectorItem(n *SelectorItem) error {
 	if n.Identifier != nil {
 		p.write(string(*n.Identifier))
 	} else {
-		p.write(string(*n.Index))
+		p.write(fmt.Sprintf("%d", *n.Index))
 	}
 
 	return nil
@@ -197,8 +200,13 @@ func (p *Printer) VisitSlice(n *SliceLiteral) error {
 	return nil
 }
 
-func (p *Printer) VisitNumber(n *NumberLiteral) error {
-	p.write(string(*n))
+func (p *Printer) VisitInteger(n *IntegerLiteral) error {
+	p.write(fmt.Sprintf("%d", *n))
+	return nil
+}
+
+func (p *Printer) VisitFloat(n *FloatLiteral) error {
+	p.write(fmt.Sprintf("%g", *n))
 	return nil
 }
 

--- a/evaluator/eval.go
+++ b/evaluator/eval.go
@@ -141,11 +141,7 @@ func (e *Evaluator) VisitSelectorItem(i *ast.SelectorItem) error {
 			return fmt.Errorf("can only access array elements with index")
 		}
 
-		index, err := strconv.ParseInt(string(*i.Index), 0, 64)
-
-		if err != nil {
-			return err
-		}
+		index := int64(*i.Index)
 
 		if index > int64(len(array.Value)) {
 			return fmt.Errorf("index %d is out of bounds", index)
@@ -164,11 +160,7 @@ func (e *Evaluator) VisitSelectorItem(i *ast.SelectorItem) error {
 			return fmt.Errorf("can only access array elements with index")
 		}
 
-		index, err := strconv.ParseInt(string(*i.Index), 0, 64)
-
-		if err != nil {
-			return err
-		}
+		index := int64(*i.Index)
 
 		if index > int64(len(array.Value)) {
 			return fmt.Errorf("index %d is out of bounds", index)
@@ -359,16 +351,19 @@ func (e *Evaluator) VisitSlice(s *ast.SliceLiteral) error {
 	return nil
 }
 
-func (e *Evaluator) VisitNumber(n *ast.NumberLiteral) error {
-	// TODO: Floats
-	value, err := strconv.ParseInt(string(*n), 0, 64)
-
-	if err != nil {
-		return err
+func (e *Evaluator) VisitInteger(n *ast.IntegerLiteral) error {
+	result := &object.Integer{
+		Value: int64(*n),
 	}
 
-	result := &object.Integer{
-		Value: value,
+	e.results.push(result)
+
+	return nil
+}
+
+func (e *Evaluator) VisitFloat(n *ast.FloatLiteral) error {
+	result := &object.Float{
+		Value: float64(*n),
 	}
 
 	e.results.push(result)

--- a/examples/main.rai
+++ b/examples/main.rai
@@ -1,15 +1,29 @@
 name: "John"
 
-greeter name {
+greeter: \name {
   greeting: "Hello, "
   (concat greeting name)
+}
+# or
+fn greeter name { 
+  greeting: "Hello, "
+  (concat greeting name)
+}
+
+exclaimed: \str -> (concat str "!")
+
+fn exclaimed str -> (concat str "!")
+
+fn exclaimed str {
+  suffix: "!"
+  (concat str suffix)
 }
 
 (println (greeter name))
 
 nums: [1 2 3]
 
-bigger_nums: (map nums \n: (add n 1))
+bigger_nums: (map nums \n -> (add n 1))
 
 (println bigger_nums)
 

--- a/examples/main.rai
+++ b/examples/main.rai
@@ -4,7 +4,7 @@ greeter: \name {
   greeting: "Hello, "
   (concat greeting name)
 }
-# or
+
 fn greeter name { 
   greeting: "Hello, "
   (concat greeting name)

--- a/examples/test.rai
+++ b/examples/test.rai
@@ -4,12 +4,12 @@ b {
   1
 }
 
-plus a b { (add a b) }
+fn plus a b { (add a b) }
 
 c: [1 2 3]
 d: { a:1 b:2 c:3}
 
-(map c \x: (add x 1))
+(map c \x -> (add x 1))
 
 (my_record.my_list.0.my_matrix.1.2)
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -111,15 +111,6 @@ func (l *Lexer) numberToken() token.Token {
 		lexeme += string(char)
 	}
 
-	if char, ok := l.current(); ok && char == '.' {
-		lexeme += "."
-		l.next()
-
-		for char, ok := l.current(); ok && isDigit(char); char, ok = l.next() {
-			lexeme += string(char)
-		}
-	}
-
 	return l.longToken(token.NUMBER, lexeme)
 }
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -86,14 +86,20 @@ func TestNumberLexing(t *testing.T) {
 
 	test.expect(source, []tokenExpect{
 		{token.NUMBER, `1`},
-		{token.NUMBER, `0.1`},
+		{token.NUMBER, `0`},
+		{token.DOT, `.`},
+		{token.NUMBER, `1`},
 		{token.MINUS, `-`},
-		{token.NUMBER, `0.1`},
+		{token.NUMBER, `0`},
+		{token.DOT, `.`},
+		{token.NUMBER, `1`},
 		{token.MINUS, `-`},
-		{token.NUMBER, `0.`},
+		{token.NUMBER, `0`},
+		{token.DOT, `.`},
 		{token.MINUS, `-`},
 		{token.NUMBER, `2`},
-		{token.NUMBER, `1.`},
+		{token.NUMBER, `1`},
+		{token.DOT, `.`},
 		{token.EOF, ``},
 	})
 }
@@ -116,7 +122,9 @@ func TestSkippingSpaces(t *testing.T) {
 
 	test.expect(source, []tokenExpect{
 		{token.IDENTIFIER, `println`},
-		{token.NUMBER, `123.1`},
+		{token.NUMBER, `123`},
+		{token.DOT, `.`},
+		{token.NUMBER, `1`},
 		{token.DOUBLE_QUOTE, `"`},
 		{token.STRING, `Raiton`},
 		{token.DOUBLE_QUOTE, `"`},
@@ -133,7 +141,9 @@ func TestSkippingNewlines(t *testing.T) {
 
 	test.expect(source, []tokenExpect{
 		{token.IDENTIFIER, `println`},
-		{token.NUMBER, `123.1`},
+		{token.NUMBER, `123`},
+		{token.DOT, `.`},
+		{token.NUMBER, `1`},
 		{token.DOUBLE_QUOTE, `"`},
 		{token.STRING, `Raiton`},
 		{token.DOUBLE_QUOTE, `"`},
@@ -159,7 +169,9 @@ func TestSkippingComments(t *testing.T) {
 		{token.DOUBLE_QUOTE, `"`},
 		{token.STRING, `Raiton`},
 		{token.DOUBLE_QUOTE, `"`},
-		{token.NUMBER, `3.14`},
+		{token.NUMBER, `3`},
+		{token.DOT, `.`},
+		{token.NUMBER, `14`},
 		{token.EOF, ``},
 	})
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -70,11 +70,36 @@ func (p *Parser) scope() (*ast.Scope, error) {
 
 func (p *Parser) scopeItem(scope *ast.Scope) error {
 	if p.match(token.IDENTIFIER) {
-		definition, err := p.definition()
+		ident := p.identifier()
+
+		switch {
+		case p.match(token.DOT):
+			selector, err := p.selector(ident)
+
+			if err != nil {
+				return err
+			}
+
+			scope.Expressions = append(scope.Expressions, selector)
+		case p.match(token.COLON) || p.match(token.OPEN_BRACE):
+			definition, err := p.definition(ident)
+
+			if err != nil {
+				return err
+			}
+
+			scope.Definitions = append(scope.Definitions, definition)
+		default:
+			scope.Expressions = append(scope.Expressions, ident)
+		}
+	} else if p.match(token.FUNCTION) {
+		funcDef, err := p.functionDefinition()
+
 		if err != nil {
 			return err
 		}
-		scope.Definitions = append(scope.Definitions, definition)
+
+		scope.Definitions = append(scope.Definitions, funcDef)
 	} else {
 		expression, err := p.expression()
 		if err != nil {
@@ -86,7 +111,44 @@ func (p *Parser) scopeItem(scope *ast.Scope) error {
 	return nil
 }
 
-func (p *Parser) definition() (*ast.Definition, error) {
+func (p *Parser) definition(ident *ast.Identifier) (*ast.Definition, error) {
+	if p.match(token.COLON) {
+		p.consume(token.COLON)
+
+		expr, err := p.expression()
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.Definition{
+			Identifier: *ident,
+			Expression: expr,
+		}, nil
+	} else if p.match(token.OPEN_BRACE) {
+		scope, err := p.scope()
+		expr := ast.Expression(scope)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.Definition{
+			Identifier: *ident,
+			Expression: expr,
+		}, nil
+	} else {
+		return nil, p.unexpected()
+	}
+}
+
+func (p *Parser) functionDefinition() (*ast.Definition, error) {
+	if err := p.expect(token.FUNCTION); err != nil {
+		return nil, err
+	}
+
+	p.consume(token.FUNCTION)
+
 	if err := p.expect(token.IDENTIFIER); err != nil {
 		return nil, err
 	}
@@ -98,15 +160,13 @@ func (p *Parser) definition() (*ast.Definition, error) {
 	parameters := []*ast.Identifier{}
 
 	for p.match(token.IDENTIFIER) {
-		param := ast.Identifier(p.token.Literal)
-		parameters = append(parameters, &param)
+		param := ast.NewIdentifier(p.token.Literal)
+		parameters = append(parameters, param)
 		p.consume(token.IDENTIFIER)
 	}
 
-	is_function := len(parameters) > 0
-
-	if p.match(token.COLON) {
-		p.consume(token.COLON)
+	if p.match(token.ARROW) {
+		p.consume(token.ARROW)
 
 		expr, err := p.expression()
 
@@ -114,11 +174,9 @@ func (p *Parser) definition() (*ast.Definition, error) {
 			return nil, err
 		}
 
-		if is_function {
-			expr = &ast.FunctionLiteral{
-				Parameters: parameters,
-				Body:       ast.ScopeExpressions(expr),
-			}
+		expr = &ast.FunctionLiteral{
+			Parameters: parameters,
+			Body:       ast.ScopeExpressions(expr),
 		}
 
 		return &ast.Definition{
@@ -133,11 +191,9 @@ func (p *Parser) definition() (*ast.Definition, error) {
 			return nil, err
 		}
 
-		if is_function {
-			expr = &ast.FunctionLiteral{
-				Parameters: parameters,
-				Body:       scope,
-			}
+		expr = &ast.FunctionLiteral{
+			Parameters: parameters,
+			Body:       scope,
 		}
 
 		return &ast.Definition{
@@ -151,7 +207,7 @@ func (p *Parser) definition() (*ast.Definition, error) {
 
 func (p *Parser) expression() (ast.Expression, error) {
 	if p.match(token.IDENTIFIER) {
-		return p.identifierPath()
+		return p.selector(nil)
 	} else if p.match(token.NUMBER) || p.match(token.MINUS) {
 		return p.number()
 	} else if p.match(token.BOOLEAN) {
@@ -179,16 +235,19 @@ func (p *Parser) identifier() *ast.Identifier {
 	return &ident
 }
 
-func (p *Parser) identifierPath() (ast.Expression, error) {
+func (p *Parser) selector(ident *ast.Identifier) (ast.Expression, error) {
 	items := []*ast.SelectorItem{}
 
-	if err := p.expect(token.IDENTIFIER); err != nil {
-		return nil, err
+	if ident == nil {
+		if err := p.expect(token.IDENTIFIER); err != nil {
+			return nil, err
+		}
+
+		ident = ast.NewIdentifier(p.token.Literal)
+		p.consume(token.IDENTIFIER)
 	}
 
-	first := p.identifier()
-	firstItem := ast.NewIdentifierSelector(first)
-
+	firstItem := ast.NewIdentifierSelector(ident)
 	items = append(items, firstItem)
 
 	for p.match(token.DOT) {
@@ -199,13 +258,7 @@ func (p *Parser) identifierPath() (ast.Expression, error) {
 			item := ast.NewIdentifierSelector(ident)
 			items = append(items, item)
 		} else if p.match(token.NUMBER) {
-			// TODO: the lexer reads decimal numbers as well, which is not ideal for this case:
-			//		 `rec.arr.2.mat.0.1` - reads `2.` and `0.1` as number tokens
-			//		 to fix this, stop the lexer from reading floats, just number sequences as unsigned integers
-			//		 that way I can parse the number properly as an integer or float, signed or unsigned in the
-			//		 p.number production method;
-			//		 plus, in the context of the selector, I can read only integers and this bug will not occurr
-			num, err := p.number()
+			num, err := p.unsignedInteger()
 
 			if err != nil {
 				return nil, err
@@ -263,6 +316,22 @@ func (p *Parser) number() (ast.Expression, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return ast.NewIntegerLiteral(value), nil
+}
+
+func (p *Parser) unsignedInteger() (ast.Expression, error) {
+	if err := p.expect(token.NUMBER); err != nil {
+		return nil, err
+	}
+
+	value, err := strconv.ParseInt(p.token.Literal, 0, 64)
+
+	if err != nil {
+		return nil, err
+	}
+
+	p.consume(token.NUMBER)
 
 	return ast.NewIntegerLiteral(value), nil
 }
@@ -430,31 +499,21 @@ func (p *Parser) function() (ast.Expression, error) {
 		Parameters: []*ast.Identifier{},
 	}
 
-	if err := p.expect(token.IDENTIFIER); err != nil {
-		return nil, err
-	}
-
-	functionLiteral.Parameters = append(functionLiteral.Parameters, ast.NewIdentifier(p.token.Literal))
-
-	p.consume(token.IDENTIFIER)
-
 	for p.match(token.IDENTIFIER) {
 		param := ast.Identifier(p.token.Literal)
 		functionLiteral.Parameters = append(functionLiteral.Parameters, &param)
 		p.consume(token.IDENTIFIER)
 	}
 
-	if p.match(token.COLON) {
-		p.consume(token.COLON)
+	if p.match(token.ARROW) {
+		p.consume(token.ARROW)
 		expr, err := p.expression()
 
 		if err != nil {
 			return &ast.Definition{}, err
 		}
 
-		functionLiteral.Body = &ast.Scope{
-			Expressions: []ast.Expression{expr},
-		}
+		functionLiteral.Body = ast.ScopeExpressions(expr)
 	} else if p.match(token.OPEN_BRACE) {
 		scope, err := p.scope()
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -211,7 +211,7 @@ func (p *Parser) identifierPath() (ast.Expression, error) {
 				return nil, err
 			}
 
-			item := ast.NewIndexSelector(num.(*ast.NumberLiteral))
+			item := ast.NewIndexSelector(num.(*ast.IntegerLiteral))
 			items = append(items, item)
 		} else {
 			return nil, p.unexpected()
@@ -227,7 +227,7 @@ func (p *Parser) number() (ast.Expression, error) {
 	numberStr := ""
 
 	if p.match(token.MINUS) {
-		numberStr += "-"
+		numberStr += p.token.Literal
 		p.consume(token.MINUS)
 	}
 
@@ -236,10 +236,35 @@ func (p *Parser) number() (ast.Expression, error) {
 	}
 
 	numberStr += p.token.Literal
-
-	num := ast.NewNumberLiteral(numberStr)
 	p.consume(token.NUMBER)
-	return num, nil
+
+	if p.match(token.DOT) {
+		numberStr += p.token.Literal
+		p.consume(token.DOT)
+
+		if err := p.expect(token.NUMBER); err != nil {
+			return nil, err
+		}
+
+		numberStr += p.token.Literal
+
+		value, err := strconv.ParseFloat(numberStr, 64)
+
+		if err != nil {
+			return nil, err
+		}
+
+		p.consume(token.NUMBER)
+		return ast.NewFloatLiteral(value), nil
+	}
+
+	value, err := strconv.ParseInt(numberStr, 0, 64)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.NewIntegerLiteral(value), nil
 }
 
 func (p *Parser) boolean() (ast.Expression, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -162,7 +162,7 @@ func TestDefinitionWithScope(t *testing.T) {
 
 func TestFunctionDefinitionWithSingleExpression(t *testing.T) {
 	source := `
-	add_two x: (add x 2)
+	fn add_two x -> (add x 2)
 	`
 
 	expected := ast.Scope{
@@ -190,7 +190,7 @@ func TestFunctionDefinitionWithSingleExpression(t *testing.T) {
 
 func TestFunctionDefinitionWithScope(t *testing.T) {
 	source := `
-	add_three x { (add x 3) }
+	fn add_three x { (add x 3) }
 	`
 
 	expected := ast.Scope{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -57,13 +57,17 @@ func TestExpressionNumber(t *testing.T) {
 
 	# number expression; negative integer
 	-1
+
+	# number expression; negative float
+	-3.14
 	`
 
 	expected := ast.Scope{
 		Expressions: []ast.Expression{
-			ast.NewNumberLiteral("5"),
-			ast.NewNumberLiteral("2.65"),
-			ast.NewNumberLiteral("-1"),
+			ast.NewIntegerLiteral(5),
+			ast.NewFloatLiteral(2.65),
+			ast.NewIntegerLiteral(-1),
+			ast.NewFloatLiteral(-3.14),
 		},
 	}
 
@@ -77,9 +81,9 @@ func TestExpressionArray(t *testing.T) {
 		Expressions: []ast.Expression{
 			ast.NewArrayLiteral(
 				3,
-				ast.NewNumberLiteral("1"),
-				ast.NewNumberLiteral("2"),
-				ast.NewNumberLiteral("3"),
+				ast.NewIntegerLiteral(1),
+				ast.NewIntegerLiteral(2),
+				ast.NewIntegerLiteral(3),
 			),
 		},
 	}
@@ -93,9 +97,9 @@ func TestExpressionSlice(t *testing.T) {
 	expected := ast.Scope{
 		Expressions: []ast.Expression{
 			ast.NewSliceLiteral(
-				ast.NewNumberLiteral("1"),
-				ast.NewNumberLiteral("2"),
-				ast.NewNumberLiteral("3"),
+				ast.NewIntegerLiteral(1),
+				ast.NewIntegerLiteral(2),
+				ast.NewIntegerLiteral(3),
 			),
 		},
 	}
@@ -146,7 +150,7 @@ func TestDefinitionWithScope(t *testing.T) {
 				Identifier: ast.Identifier("age"),
 				Expression: &ast.Scope{
 					Expressions: []ast.Expression{
-						ast.NewNumberLiteral("24"),
+						ast.NewIntegerLiteral(24),
 					},
 				},
 			},
@@ -173,7 +177,7 @@ func TestFunctionDefinitionWithSingleExpression(t *testing.T) {
 						ast.NewApplication(
 							ast.NewSelector(ast.NewIdentifierSelector(ast.NewIdentifier("add"))),
 							ast.NewSelector(ast.NewIdentifierSelector(ast.NewIdentifier("x"))),
-							ast.NewNumberLiteral("2"),
+							ast.NewIntegerLiteral(2),
 						),
 					),
 				},
@@ -201,7 +205,7 @@ func TestFunctionDefinitionWithScope(t *testing.T) {
 						ast.NewApplication(
 							ast.NewSelector(ast.NewIdentifierSelector(ast.NewIdentifier("add"))),
 							ast.NewSelector(ast.NewIdentifierSelector(ast.NewIdentifier("x"))),
-							ast.NewNumberLiteral("3"),
+							ast.NewIntegerLiteral(3),
 						),
 					),
 				},

--- a/token/token.go
+++ b/token/token.go
@@ -25,6 +25,7 @@ func (t *Token) Print(w io.Writer) {
 var KEYWORDS = map[string]TokenType{
 	"true":  BOOLEAN,
 	"false": BOOLEAN,
+	"fn":    FUNCTION,
 }
 
 var SYMBOLS = map[string]TokenType{
@@ -48,6 +49,7 @@ const (
 	STRING     = "string"
 	NUMBER     = "number"
 	BOOLEAN    = "boolean"
+	FUNCTION   = "function"
 
 	OPEN_PAREN     = "left_paren"
 	CLOSED_PAREN   = "right_paren"

--- a/token/token.go
+++ b/token/token.go
@@ -40,6 +40,7 @@ var SYMBOLS = map[string]TokenType{
 	"\\": BACKSLASH,
 	"-":  MINUS,
 	".":  DOT,
+	"->": ARROW,
 }
 
 const (
@@ -61,6 +62,7 @@ const (
 	BACKSLASH    = "backslash"
 	MINUS        = "minus"
 	DOT          = "dot"
+	ARROW        = "arrow"
 
 	EOF     = "eof"
 	ILLEGAL = "illegal"


### PR DESCRIPTION
Now the parser allows only for simple definitions:
```
<identifier> : <expression>
```
The `<expression>` can be any valid expression, including function literals.
Function literals are now written as  `\<parameters> -> <expression>` or `\<parameters> { <expressions> }`.

Functions can be defined explicitly like this:
```
fn <identifier> <parameters> -> <expression>
# or
fn <identifier> <parameters> { <expressions> }
```

Because of these changes to how functions are defined, selectors are now valid expressions at the scope level:
```
yusuf {
  greetings: ["Selamu Alaykum", "Merhaba", "Hello", "Hi"]
  person: { name: "Yusuf" age: 25 greeting: greetings.0 }

  person
}
```

Selectors now also allow proper array indexing:
```
rec: { arr: [ 1 2 { mat: [[1 2 3] [4 5 6] [7 8 9]] } 4 5 ] }  
rec.arr.2.mat.0.2 # evaluates to 2
```
